### PR TITLE
chore: potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/components/article-copyright.test.ts
+++ b/components/article-copyright.test.ts
@@ -32,7 +32,18 @@ describe('ArticleCopyright', () => {
 
         // Should have a link to the license
         const links = wrapper.findAll('.article-copyright__link')
-        expect(links.some((l) => l.attributes('href')?.includes('creativecommons.org'))).toBe(true)
+        expect(
+            links.some((l) => {
+                const href = l.attributes('href')
+                if (!href) return false
+                try {
+                    const url = new URL(href)
+                    return url.host === 'creativecommons.org'
+                } catch {
+                    return false
+                }
+            }),
+        ).toBe(true)
     })
 
     it('falls back to default license from config', async () => {


### PR DESCRIPTION
Potential fix for [https://github.com/CaoMeiYouRen/momei/security/code-scanning/11](https://github.com/CaoMeiYouRen/momei/security/code-scanning/11)

In general, to fix incomplete URL substring sanitization you should parse the URL and assert against its structured components (like `host` or `origin`) instead of checking for substrings anywhere in the URL string. For whitelisting, compare the parsed host against an explicit list of allowed hosts or exact expected values.

For this specific test, we should stop using `.includes('creativecommons.org')` and instead parse each `href` into a `URL` object, then compare `url.host` to the expected host (`'creativecommons.org'`). This keeps the test’s intent (“there is at least one link to the Creative Commons site”) while ensuring that `creativecommons.org` is actually the hostname and not just part of a path, query, or a longer, malicious hostname. The rest of the test behavior (finding links and asserting that at least one is a CC link) remains unchanged.

Concretely, in `components/article-copyright.test.ts`, on line 35 we replace:

```ts
expect(links.some((l) => l.attributes('href')?.includes('creativecommons.org'))).toBe(true)
```

with code that:

1. Retrieves the `href`.
2. Safely attempts to construct a `new URL(href)`.
3. Checks `url.host === 'creativecommons.org'`.
4. Treats invalid/missing URLs as non-matches.

No new imports are needed because `URL` is available in the Node/Vitest environment. The change is limited to that one expectation line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
